### PR TITLE
replace .cuda() to .to(device)

### DIFF
--- a/decoder_zoo/VCD/README.md
+++ b/decoder_zoo/VCD/README.md
@@ -62,8 +62,8 @@ set the hyperparameter in the `generate` function:
 ```python
 output_ids = model.generate(
     input_ids,
-    images=image_tensor.unsqueeze(0).half().cuda(),
-    images_cd=(image_tensor_cd.unsqueeze(0).half().cuda() if image_tensor_cd is not None else None),
+    images=image_tensor.unsqueeze(0).half().to(model.device),
+    images_cd=(image_tensor_cd.unsqueeze(0).half().to(model.device) if image_tensor_cd is not None else None),
     cd_alpha = args.cd_alpha,
     cd_beta = args.cd_beta,
     do_sample=True)

--- a/decoder_zoo/VCD/experiments/eval/object_hallucination_vqa_qwenvl.py
+++ b/decoder_zoo/VCD/experiments/eval/object_hallucination_vqa_qwenvl.py
@@ -56,8 +56,8 @@ def eval_model(args):
             image_tensor_cd = None   
         
         pred = model.generate(
-            input_ids=input_ids.input_ids.cuda(),
-            attention_mask=input_ids.attention_mask.cuda(),
+            input_ids=input_ids.input_ids.to(model.device),
+            attention_mask=input_ids.attention_mask.to(model.device),
             do_sample=True,
             max_new_tokens=20,
             min_new_tokens=1,
@@ -70,10 +70,10 @@ def eval_model(args):
             temperature=args.temperature,
             top_p=args.top_p,
             top_k=args.top_k,
-            images = image_tensor,
+            images=image_tensor,
             images_cd=image_tensor_cd,
-            cd_beta = args.cd_beta,
-            cd_alpha = args.cd_alpha,
+            cd_beta=args.cd_beta,
+            cd_alpha=args.cd_alpha,
         )
 
         outputs = [

--- a/run_scripts/caption_generation.py
+++ b/run_scripts/caption_generation.py
@@ -477,7 +477,7 @@ for idx, img_id in tqdm(enumerate(range(len(img_files))), total=len(img_files)):
     if vcd_decoding:
         image_tensor_cd = add_diffusion_noise(image, args.noise_step)
         image_cd = (
-            image_tensor_cd.unsqueeze(0).half().cuda()
+            image_tensor_cd.unsqueeze(0).half().to(device)
             if image_tensor_cd is not None
             else None
         )

--- a/run_scripts/demo_inference.py
+++ b/run_scripts/demo_inference.py
@@ -353,11 +353,7 @@ for image_path in img_path_list:
     image_cd = None
     if decoding_strategy == "vcd":
         image_tensor_cd = add_diffusion_noise(image, args.noise_step)
-        image_cd = (
-            image_tensor_cd.unsqueeze(0).half().cuda()
-            if image_tensor_cd is not None
-            else None
-        )
+        image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
         cd_alpha = cd_alpha
         cd_beta = cd_beta
         if model_name == "minigpt4":

--- a/run_scripts/mme_eval.py
+++ b/run_scripts/mme_eval.py
@@ -468,11 +468,7 @@ for idx in tqdm(range(iterations)):
 
     if vcd_decoding:
         image_tensor_cd = add_diffusion_noise(image, args.noise_step)
-        image_cd = (
-            image_tensor_cd.unsqueeze(0).half().cuda()
-            if image_tensor_cd is not None
-            else None
-        )
+        image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
         cd_alpha = cd_alpha
         cd_beta = cd_beta
         print("image_cd", image_cd.shape)

--- a/run_scripts/omme_eval.py
+++ b/run_scripts/omme_eval.py
@@ -424,11 +424,7 @@ for idx, img_id in tqdm(enumerate(range(len(img_files))), total=len(img_files)):
 
     if vcd_decoding:
         image_tensor_cd = add_diffusion_noise(image, args.noise_step)
-        image_cd = (
-            image_tensor_cd.unsqueeze(0).half().cuda()
-            if image_tensor_cd is not None
-            else None
-        )
+        image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
         cd_alpha = cd_alpha
         cd_beta = cd_beta
         print("image_cd", image_cd.shape)

--- a/run_scripts/pope_eval.py
+++ b/run_scripts/pope_eval.py
@@ -558,11 +558,7 @@ def main():
 
         if vcd_decoding:
             image_tensor_cd = add_diffusion_noise(image, args.noise_step)
-            image_cd = (
-                image_tensor_cd.unsqueeze(0).half().cuda()
-                if image_tensor_cd is not None
-                else None
-            )
+            image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
             cd_alpha = cd_alpha
             cd_beta = cd_beta
             print("image_cd", image_cd.shape)

--- a/run_scripts/test.py
+++ b/run_scripts/test.py
@@ -351,11 +351,7 @@ for image_path in img_path_list:
     image_cd = None
     if decoding_strategy == "vcd":
         image_tensor_cd = add_diffusion_noise(image, args.noise_step)
-        image_cd = (
-            image_tensor_cd.unsqueeze(0).half().cuda()
-            if image_tensor_cd is not None
-            else None
-        )
+        image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
         cd_alpha = cd_alpha
         cd_beta = cd_beta
         if model_name == "minigpt4":


### PR DESCRIPTION
When I perform inference using VCD method with a GPU whose GPU ID is not 0, for instance, while running `caption_generation.py`, I encounter an error during the model's forward pass. The error occurs because the tensors being processed are not on the same GPU.

Upon investigation, it was found that the `image_cd` torch.Tensor is located on CUDA:0, whereas the other tensors, including the model `model`, are on the correct GPU, such as CUDA:1. This discrepancy causes the error. To resolve this issue, I changed `.cuda()` in the code to `.to(device)` or `.to(model.device)`, thereby ensuring all tensors and the model are on the same device and avoiding the problem. 

``` python 
if vcd_decoding:
    image_tensor_cd = add_diffusion_noise(image, args.noise_step)
    image_cd = image_tensor_cd.unsqueeze(0).half().cuda() if image_tensor_cd is not None else None
    print("image_cd", image_cd.shape)
    print(cd_alpha, cd_beta, args.noise_step)
    if model_name == "minigpt4":
        image_cd = image_cd.squeeze(0)
 ```
 Is change to:
 ``` python 
if vcd_decoding:
    image_tensor_cd = add_diffusion_noise(image, args.noise_step)
    image_cd = image_tensor_cd.unsqueeze(0).half().to(device) if image_tensor_cd is not None else None
    print("image_cd", image_cd.shape)
    print(cd_alpha, cd_beta, args.noise_step)
    if model_name == "minigpt4":
        image_cd = image_cd.squeeze(0)
 ```